### PR TITLE
Optimize release-mode builds for better binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,8 @@ unsafe-code = "forbid"
 [lints.clippy]
 cargo = "warn"
 pedantic = "warn"
+
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true


### PR DESCRIPTION
Empirically, this shrinks the final binary size from 2.2M to 1.3M (tested on Ubuntu 24.04 with Rust 1.83), while only costing a few extra seconds of build time

Resolves #2